### PR TITLE
add localhost to /etc/hosts as it seems to be a prerequise for postgresql installation

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -37,7 +37,8 @@ dpkg-reconfigure locales
 
 echo "$SYSTEM_HOSTNAME" > /etc/hostname
 # update host file
-sed -i "s/\([^-]\)localhost/\1$SYSTEM_HOSTNAME/" /etc/hosts
+# sed -i "s/\([^-]\)localhost/\1$SYSTEM_HOSTNAME/" /etc/hosts
+echo "127.0.0.1 $SYSTEM_HOSTNAME" >> /etc/hosts
 
 hostname openerp
 


### PR DESCRIPTION
starting the postgresql database was failing because localhost was expected to be present in /etc/hosts.
I propose here to add it in addition in the hosts as it was previously replaced by actual host name.
